### PR TITLE
Fix NIOVTaskDeferredMask memory leak

### DIFF
--- a/skee/TintMaskInterface.cpp
+++ b/skee/TintMaskInterface.cpp
@@ -156,7 +156,7 @@ NIOVTaskDeferredMask::NIOVTaskDeferredMask(TESObjectREFR * refr, bool isFirstPer
 
 void NIOVTaskDeferredMask::Dispose()
 {
-
+	delete this;
 }
 
 void NIOVTaskDeferredMask::Run()


### PR DESCRIPTION
ItemDataInterface::OnAttach intercepts attached armor geometry, passes it to NIOVTaskDeferredMask which is never released resulting in a potentially massive memory hog as armors load in.