### PR TITLE
Fix VR deferred task lifetime and body morph publication

### DIFF
--- a/skee/BodyMorphInterface.cpp
+++ b/skee/BodyMorphInterface.cpp
@@ -416,8 +416,9 @@ bool BodyMorphMap::HasMorphs(TESObjectREFR * refr) const
 #include <d3d11.h>
 #include <d3d11_4.h>
 
-void MorphFileCache::ApplyMorph(TESObjectREFR * refr, NiAVObject * rootNode, bool isAttaching, const std::pair<SKEEFixedString, BodyMorphMap> & bodyMorph, std::mutex * mutex, bool deferred)
+NIOVTaskUpdateSkinPartition * MorphFileCache::ApplyMorph(TESObjectREFR * refr, NiAVObject * rootNode, bool isAttaching, const std::pair<SKEEFixedString, BodyMorphMap> & bodyMorph)
 {
+	NIOVTaskUpdateSkinPartition * updateTask = nullptr;
 	BSFixedString nodeName = bodyMorph.first.c_str();
 	BSGeometry * geometry = rootNode->GetAsBSGeometry();
 	NiGeometry * legacyGeometry = rootNode->GetAsNiGeometry();
@@ -578,21 +579,8 @@ void MorphFileCache::ApplyMorph(TESObjectREFR * refr, NiAVObject * rootNode, boo
 										memcpy(pPartition.shapeData->m_RawVertexData, partition.shapeData->m_RawVertexData, newSkinPartition->vertexCount * vertexSize);
 									}
 
-									if (mutex) mutex->lock();
-
-									auto updateTask = new NIOVTaskUpdateSkinPartition(skinInstance, newSkinPartition);
+									updateTask = new NIOVTaskUpdateSkinPartition(skinInstance, newSkinPartition);
 									newSkinPartition->DecRef(); // DeepCopy started refcount at 1, passed ownership to the task
-
-									if (deferred)
-									{
-										g_task->AddTask(updateTask);
-									}
-									else
-									{
-										updateTask->Run();
-										updateTask->Dispose();
-									}
-									if (mutex) mutex->unlock();
 								}
 							}
 						}
@@ -601,20 +589,29 @@ void MorphFileCache::ApplyMorph(TESObjectREFR * refr, NiAVObject * rootNode, boo
 			}
 		}
 	}
+
+	return updateTask;
 }
 
 void MorphFileCache::ApplyMorphs(TESObjectREFR * refr, NiAVObject * rootNode, bool isAttaching, bool defer)
 {
+	std::vector<NIOVTaskUpdateSkinPartition *> updateTasks;
+	updateTasks.reserve(vertexMap.size());
 	if (g_parallelMorphing)
 	{
-		std::mutex mtx;
 		concurrency::structured_task_group task_group;
 		std::vector<concurrency::task_handle<std::function<void()>>> task_list;
+		std::vector<NIOVTaskUpdateSkinPartition *> parallelUpdates(vertexMap.size(), nullptr);
+		task_list.reserve(vertexMap.size());
+
+		std::size_t resultIndex = 0;
 		for (const auto & it : vertexMap)
 		{
-			task_list.push_back(concurrency::make_task<std::function<void()>>([&]()
+			auto item = &it;
+			auto index = resultIndex++;
+			task_list.push_back(concurrency::make_task<std::function<void()>>([this, refr, rootNode, isAttaching, item, index, &parallelUpdates]()
 			{
-				ApplyMorph(refr, rootNode, isAttaching, it, &mtx, defer);
+				parallelUpdates[index] = ApplyMorph(refr, rootNode, isAttaching, *item);
 			}));
 		}
 		for (auto & task : task_list)
@@ -623,12 +620,40 @@ void MorphFileCache::ApplyMorphs(TESObjectREFR * refr, NiAVObject * rootNode, bo
 		}
 
 		task_group.wait();
+
+		// Do not enqueue renderer-facing tasks from a ConcRT worker. ApplyMorphs
+		// can itself run inside SKSE's task dispatcher while its queue lock is
+		// held. A worker calling AddTask while the dispatcher waits here creates
+		// a queue-lock / task-group lock inversion. Collect results in stable
+		// slots, join every CPU morph, and publish only on the calling thread.
+		for (auto update : parallelUpdates)
+		{
+			if (update)
+				updateTasks.push_back(update);
+		}
 	}
 	else
 	{
 		for (const auto & it : vertexMap)
 		{
-			ApplyMorph(refr, rootNode, isAttaching, it, nullptr, defer);
+			auto update = ApplyMorph(refr, rootNode, isAttaching, it);
+			if (update)
+				updateTasks.push_back(update);
+		}
+	}
+
+	// Finish all CPU morph work before exposing any updated armor shape to
+	// the renderer. This keeps a single attachment internally consistent.
+	for (auto update : updateTasks)
+	{
+		if (defer)
+		{
+			g_task->AddTask(update);
+		}
+		else
+		{
+			update->Run();
+			update->Dispose();
 		}
 	}
 }
@@ -1152,12 +1177,46 @@ void NIOVTaskUpdateSkinPartition::Run()
 		UInt32 vertexCount = m_partition->vertexCount;
 
 		auto deviceContext = g_renderManager->context;
-		deviceContext->UpdateSubresource(partition.shapeData->m_VertexBuffer, 0, nullptr, partition.shapeData->m_RawVertexData, vertexCount * vertexSize, 0);
-
-		for (UInt32 p = 1; p < m_partition->m_uiPartitions; ++p)
+		for (UInt32 p = 0; p < m_partition->m_uiPartitions; ++p)
 		{
 			auto & pPartition = m_partition->m_pkPartitions[p];
-			deviceContext->UpdateSubresource(pPartition.shapeData->m_VertexBuffer, 0, nullptr, pPartition.shapeData->m_RawVertexData, vertexCount * vertexSize, 0);
+			auto vertexBuffer = pPartition.shapeData->m_VertexBuffer;
+			if (!vertexBuffer)
+				continue;
+
+			// Deep-copied partitions can share the same GPU resource. Submit each
+			// resource only once rather than racing duplicate updates.
+			bool alreadyUpdated = false;
+			for (UInt32 previous = 0; previous < p; ++previous)
+			{
+				if (m_partition->m_pkPartitions[previous].shapeData->m_VertexBuffer == vertexBuffer)
+				{
+					alreadyUpdated = true;
+					break;
+				}
+			}
+			if (alreadyUpdated)
+				continue;
+
+			D3D11_BUFFER_DESC desc{};
+			vertexBuffer->GetDesc(&desc);
+			if (desc.Usage == D3D11_USAGE_DYNAMIC && (desc.CPUAccessFlags & D3D11_CPU_ACCESS_WRITE))
+			{
+				D3D11_MAPPED_SUBRESOURCE mapped{};
+				if (SUCCEEDED(deviceContext->Map(vertexBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped)))
+				{
+					memcpy(mapped.pData, pPartition.shapeData->m_RawVertexData, vertexCount * vertexSize);
+					deviceContext->Unmap(vertexBuffer, 0);
+				}
+			}
+			else if (desc.Usage == D3D11_USAGE_DEFAULT)
+			{
+				deviceContext->UpdateSubresource(vertexBuffer, 0, nullptr, pPartition.shapeData->m_RawVertexData, vertexCount * vertexSize, 0);
+			}
+			else
+			{
+				_ERROR("%s - Unsupported body morph vertex buffer usage %u", __FUNCTION__, desc.Usage);
+			}
 		}
 
 		m_skinInstance->m_spSkinPartition = m_partition;

--- a/skee/BodyMorphInterface.h
+++ b/skee/BodyMorphInterface.h
@@ -26,7 +26,6 @@
 #include <functional>
 #include <memory>
 #include <ctime>
-#include <mutex>
 
 #include <DirectXMath.h>
 #include <DirectXPackedVector.h>
@@ -197,13 +196,15 @@ public:
 	UInt32 memoryUsage;
 };
 
+class NIOVTaskUpdateSkinPartition;
+
 class MorphFileCache
 {
 	friend class MorphCache;
 	friend class BodyMorphInterface;
 public:
 	void ApplyMorphs(TESObjectREFR * refr, NiAVObject * rootNode, bool erase = false, bool defer = false);
-	void ApplyMorph(TESObjectREFR * refr, NiAVObject * rootNode, bool erase, const std::pair<SKEEFixedString, BodyMorphMap> & bodyMorph, std::mutex * mtx = nullptr, bool deferred = true);
+	NIOVTaskUpdateSkinPartition * ApplyMorph(TESObjectREFR * refr, NiAVObject * rootNode, bool erase, const std::pair<SKEEFixedString, BodyMorphMap> & bodyMorph);
 
 private:
 	TriShapeMap vertexMap;

--- a/skee/Morpher.cpp
+++ b/skee/Morpher.cpp
@@ -7,6 +7,7 @@
 #undef max
 #endif
 #include "half.hpp"
+#include <DirectXMath.h>
 #include "skse64/NiGeometry.h"
 
 float round_v(float num)
@@ -14,7 +15,9 @@ float round_v(float num)
 	return (num > 0.0) ? floor(num + 0.5) : ceil(num - 0.5);
 }
 
-NormalApplicator::NormalApplicator(NiPointer<BSGeometry> _geometry, NiPointer<NiSkinPartition> _skinPartition) : geometry(_geometry)
+NormalApplicator::NormalApplicator(NiPointer<BSGeometry> _geometry, NiPointer<NiSkinPartition> _skinPartition)
+	: geometry(_geometry)
+	, skinPartition(_skinPartition)
 {
 	BSDynamicTriShape * dynamicTriShape = ni_cast(geometry, BSDynamicTriShape);
 	BSTriShape * triShape = ni_cast(geometry, BSTriShape);
@@ -23,17 +26,13 @@ NormalApplicator::NormalApplicator(NiPointer<BSGeometry> _geometry, NiPointer<Ni
 
 	UInt64 vertexDesc = geometry->vertexDesc;
 	UInt32 numVertices = triShape ? triShape->numVertices : 0;
-	UInt8* vertexBlock = nullptr;
-
+	bool hasVertices = (NiSkinPartition::GetVertexFlags(vertexDesc) & VertexFlags::VF_VERTEX) == VertexFlags::VF_VERTEX;
 	bool hasNormals = (NiSkinPartition::GetVertexFlags(vertexDesc) & VertexFlags::VF_NORMAL) == VertexFlags::VF_NORMAL;
 	bool hasTangents = (NiSkinPartition::GetVertexFlags(vertexDesc) & VertexFlags::VF_TANGENT) == VertexFlags::VF_TANGENT;
 	bool hasUV = (NiSkinPartition::GetVertexFlags(vertexDesc) & VertexFlags::VF_UV) == VertexFlags::VF_UV;
 
-	const NiSkinInstance * skinInstance = geometry->m_spSkinInstance.m_pObject;
-	if (skinInstance && (hasNormals || hasTangents)) {
-		const NiSkinPartition * skinPartition = skinInstance->m_spSkinPartition.m_pObject;
-		if (skinPartition) {
-			numVertices = numVertices ? numVertices : skinPartition->vertexCount;
+	if (skinPartition && (hasNormals || hasTangents)) {
+		numVertices = numVertices ? numVertices : skinPartition->vertexCount;
 
 			// Pull the base data from the vertex block
 			rawVertices.resize(numVertices);
@@ -49,19 +48,34 @@ NormalApplicator::NormalApplicator(NiPointer<BSGeometry> _geometry, NiPointer<Ni
 				}
 			}
 
-			UInt32 vertexSize = NiSkinPartition::GetVertexSize(vertexDesc);
+		UInt32 vertexSize = NiSkinPartition::GetVertexSize(vertexDesc);
 
-			vertexBlock = dynamicTriShape ? reinterpret_cast<UInt8*>(dynamicTriShape->pDynamicData) : reinterpret_cast<UInt8*>(skinPartition->m_pkPartitions[0].shapeData->m_RawVertexData);
+		// Recalculate the cloned partition that will be installed by the update
+		// task. The VR branch previously ignored _skinPartition and modified
+		// the currently rendered partition instead.
+		UInt8* vertexBlock = reinterpret_cast<UInt8*>(skinPartition->m_pkPartitions[0].shapeData->m_RawVertexData);
+
+		if (dynamicTriShape && !hasVertices)
+		{
+			for (UInt32 i = 0; i < numVertices; ++i)
+			{
+				DirectX::XMVECTOR* vertices = static_cast<DirectX::XMVECTOR*>(dynamicTriShape->pDynamicData);
+				DirectX::XMStoreFloat3(reinterpret_cast<DirectX::XMFLOAT3*>(&rawVertices[i]), vertices[i]);
+			}
+		}
 
 			for (UInt32 i = 0; i < numVertices; i++)
 			{
 				UInt8 * vBegin = &vertexBlock[i * vertexSize];
 
-				rawVertices[i].x = (*(float *)vBegin); vBegin += sizeof(float);
-				rawVertices[i].y = (*(float *)vBegin); vBegin += sizeof(float);
-				rawVertices[i].z = (*(float *)vBegin); vBegin += sizeof(float);
+				if (hasVertices)
+				{
+					rawVertices[i].x = (*(float *)vBegin); vBegin += sizeof(float);
+					rawVertices[i].y = (*(float *)vBegin); vBegin += sizeof(float);
+					rawVertices[i].z = (*(float *)vBegin); vBegin += sizeof(float);
 
-				vBegin += 4; // Skip BitangetX
+					vBegin += 4; // Skip BitangentX
+				}
 
 				if (NiSkinPartition::GetVertexFlags(vertexDesc) & VertexFlags::VF_UV)
 				{
@@ -86,13 +100,16 @@ NormalApplicator::NormalApplicator(NiPointer<BSGeometry> _geometry, NiPointer<Ni
 			{
 				UInt8 * vBegin = &vertexBlock[i * vertexSize];
 
-				// X,Y,Z,BX
-				vBegin += sizeof(float);
-				vBegin += sizeof(float);
-				vBegin += sizeof(float);
+				if (hasVertices)
+				{
+					// X,Y,Z,BX
+					vBegin += sizeof(float);
+					vBegin += sizeof(float);
+					vBegin += sizeof(float);
 
-				// No need to write bitangentX
-				*(float *)vBegin = rawBitangents[i].x; vBegin += sizeof(float);
+					// No need to write bitangentX
+					*(float *)vBegin = rawBitangents[i].x; vBegin += sizeof(float);
+				}
 
 				// Skip UV write
 				if (hasUV)
@@ -118,7 +135,6 @@ NormalApplicator::NormalApplicator(NiPointer<BSGeometry> _geometry, NiPointer<Ni
 					}
 				}
 			}
-		}
 	}
 
 	if (dynamicTriShape) dynamicTriShape->lock.Release();

--- a/skee/TintMaskInterface.cpp
+++ b/skee/TintMaskInterface.cpp
@@ -156,7 +156,7 @@ NIOVTaskDeferredMask::NIOVTaskDeferredMask(TESObjectREFR * refr, bool isFirstPer
 
 void NIOVTaskDeferredMask::Dispose()
 {
-
+	delete this;
 }
 
 void NIOVTaskDeferredMask::Run()


### PR DESCRIPTION
## Summary

This fixes two VR-specific asynchronous task/lifetime defects, kept as separate commits:

1. Release completed deferred tint-mask tasks.
2. Make body-morph generation, publication, normal recalculation, and GPU-buffer updates safe on the VR path.

No project files, build outputs, or binaries are included.

## Deferred tint-mask lifetime

The VR implementation of `NIOVTaskDeferredMask::Dispose()` was empty, while the current non-VR implementation deletes the task. Each completed VR task therefore retained its `NiPointer<NiAVObject>` and the detached actor armor/object graph beneath it.

The first commit restores `delete this;`.

A live heap/scene-owner trace followed the retained chain from an inactive outfit texture through its shader material/property and detached node to `NIOVTaskDeferredMask::m_object`. Before the patch, 730 live task objects were found and the count later increased to 841 without repeating the route. After the patch, the coherent departed-cell actor/outfit texture cohort was absent; the remaining warmed-route retention converged and was dominated by unrelated D3D/TBB cache churn.

## Body morph task publication

The old parallel path could run inside SKSE's task dispatcher, start ConcRT workers, and wait for them while the dispatcher retained its task-queue critical section. A worker then took RaceMenu's local morph mutex and called `g_task->AddTask()`, producing the queue-lock/task-group inversion reported in #63.

The second commit makes workers perform CPU morph generation only. Results are written to stable per-item slots, all workers are joined, and renderer-facing update tasks are then published from the calling thread. It also:

- recalculates tangent space on the cloned partition that will actually be installed;
- maps writable dynamic vertex buffers with `D3D11_MAP_WRITE_DISCARD`;
- keeps `UpdateSubresource` for default-usage buffers;
- avoids duplicate updates when partitions share the same GPU buffer; and
- diagnoses unsupported buffer usages instead of issuing an invalid update.

## Validation

Built successfully as a Release x64 VR DLL.

Runtime validation used `bParallelMorphing=1`:

- five settled Riften/Markarth COC legs completed;
- 60 explicit `Actor.QueueNiNodeUpdate` calls completed across five NPCs;
- 20 controlled cuirass detach/reattach cycles plus node rebuilds completed all 100 steps in 8.921 seconds;
- the original cuirass was confirmed restored and equipped;
- Skyrim remained responsive and produced no new crash log;
- no unsupported-buffer or related RaceMenu diagnostic was emitted.

The deferred-task disposal and body-morph changes are intentionally separate commits so either can be reviewed or cherry-picked independently.

## Binary distribution permission

This repository does not include a software licence, and RaceMenu's published permissions restrict reuploads. I have a locally built test DLL for this PR but have not distributed it.

Would you permit a temporary, non-monetized Discord test package containing only the patched `skeevr.dll`, requiring users to install the original RaceMenu VR and including attribution plus links to the original mod and this PR? If not, I will keep the binary private and share only the PR/source-build route.